### PR TITLE
max negative value on 1st read for accelerometer and gyroscope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2024-06-27
 ### Added
 - Initial release of the BMI323 Rust driver.
-- Support for both I2C and SPI interfaces.
+- Support for both I2C and SPI interfaces (SPI not validated).
 - Configurable accelerometer and gyroscope settings.
 - Functions to read raw and scaled sensor data.
 - Error handling and device initialization.

--- a/src/device.rs
+++ b/src/device.rs
@@ -9,6 +9,12 @@ impl<I2C, D> Bmi323<I2cInterface<I2C>, D>
 where
     D: DelayNs,
 {
+    /// Create a new BMI323 device instance
+    ///
+    /// # Arguments
+    ///
+    /// * `iface` - The communication interface
+    /// * `delay` - A delay provider
     pub fn new_with_i2c(i2c: I2C, address: u8, delay: D) -> Self {
         Bmi323 {
             iface: I2cInterface { i2c, address },
@@ -23,6 +29,12 @@ impl<SPI, D> Bmi323<SpiInterface<SPI>, D>
 where
     D: DelayNs,
 {
+    /// Create a new BMI323 device instance
+    ///
+    /// # Arguments
+    ///
+    /// * `iface` - The communication interface
+    /// * `delay` - A delay provider
     pub fn new_with_spi(spi: SPI, delay: D) -> Self {
         Bmi323 {
             iface: SpiInterface { spi },
@@ -38,21 +50,6 @@ where
     DI: ReadData<Error = Error<E>> + WriteData<Error = Error<E>>,
     D: DelayNs,
 {
-    /// Create a new BMI323 device instance
-    ///
-    /// # Arguments
-    ///
-    /// * `iface` - The communication interface (I2C or SPI)
-    /// * `delay` - A delay provider
-    pub fn new(iface: DI, delay: D) -> Self {
-        Self {
-            iface,
-            delay,
-            accel_range: AccelerometerRange::default(),
-            gyro_range: GyroscopeRange::default(),
-        }
-    }
-
     /// Initialize the device
     pub fn init(&mut self) -> Result<(), Error<E>> {
         //self.set_command_register(Register::CMD_SOFT_RESET)?;
@@ -76,53 +73,6 @@ where
 
         Ok(())
     }
-
-    /// Soft reset the device
-    /// Perform a soft reset of the BMI323 device
-    /*
-    fn soft_reset(&mut self) -> Result<(), Error<E>> {
-        self.write_register_16bit(Register::CMD, Register::CMD_SOFT_RESET)?;
-        self.delay.delay_ms(2);
-
-        // Perform setup
-        let setups = [
-            (Register::FEATURE_IO2, [0x2c, 0x01]),
-            (Register::FEATURE_IO_STATUS, [0x01, 0]),
-            (Register::FEATURE_CTRL, [0x01, 0]),
-        ];
-
-        for (reg, data) in setups.iter() {
-            self.write_register_16bit(*reg, u16::from_le_bytes(*data))?;
-        }
-
-        // Polling loop
-        for _ in 0..10 {
-            self.delay.delay_ms(100);
-            let mut reg_data = [0u8; 2];
-            reg_data[0] = Register::FEATURE_IO1;
-            self.read_data(&mut reg_data)?;
-            if reg_data[0] == 1 {
-                break;
-            }
-        }
-
-        Ok(())
-        }
-
-    /// Set a command in the command register
-    fn set_command_register(&mut self, command: u16) -> Result<(), Error<E>> {
-        const BMI3_SET_LOW_BYTE: u16 = 0x00FF;
-        const BMI3_SET_HIGH_BYTE: u16 = 0xFF00;
-
-        let reg_data = [
-            (command & BMI3_SET_LOW_BYTE) as u8,
-            ((command & BMI3_SET_HIGH_BYTE) >> 8) as u8,
-        ];
-
-        self.write_register_16bit(command, u16::from_le_bytes(reg_data))?;
-
-        Ok(())
-        }*/
 
     /// Set the accelerometer configuration
     ///
@@ -173,41 +123,27 @@ where
         })
     }
 
+    /// Read the LSB for the accelerometer
     pub fn read_accel_data(&mut self) -> Result<Sensor3DData, Error<E>> {
         self.read_sensor_data(SensorType::Accelerometer)
     }
 
+    /// Read the LSB for the gyroscope
     pub fn read_gyro_data(&mut self) -> Result<Sensor3DData, Error<E>> {
         self.read_sensor_data(SensorType::Gyroscope)
     }
 
+    /// Read the LSB for the accelerometer and return the scaled value as mps2
     pub fn read_accel_data_scaled(&mut self) -> Result<Sensor3DDataScaled, Error<E>> {
         let raw_data = self.read_accel_data()?;
         Ok(raw_data.to_mps2(self.accel_range.to_g())) // Assuming 16-bit width
     }
 
+    /// Read the LSB for the gyroscope and return the scaled value as dps
     pub fn read_gyro_data_scaled(&mut self) -> Result<Sensor3DDataScaled, Error<E>> {
         let raw_data = self.read_gyro_data()?;
         Ok(raw_data.to_dps(self.gyro_range.to_dps())) // Assuming 16-bit width
     }
-
-    /*
-    pub fn read_temperature(&mut self) -> Result<f32, Error<E>> {
-        let mut data = [0u8; 2];
-        self.read_data(&mut data)?;
-        let raw_temp = i16::from_le_bytes([data[0], data[1]]);
-        Ok((raw_temp as f32 / 512.0) + 23.0)
-    }
-
-    pub fn read_sensor_time(&mut self) -> Result<u32, Error<E>> {
-        let mut data = [0u8; 3];
-        self.read_data(&mut data)?;
-        Ok(u32::from_le_bytes([data[0], data[1], data[2], 0]))
-        }
-
-    fn write_register(&mut self, reg: u8, value: u8) -> Result<(), Error<E>> {
-        self.iface.write_register(reg, value)
-        }*/
 
     fn write_register_16bit(&mut self, reg: u8, value: u16) -> Result<(), Error<E>> {
         let bytes = value.to_le_bytes();

--- a/src/device.rs
+++ b/src/device.rs
@@ -59,7 +59,7 @@ where
         //let mut reg_data = [0u8; 3];
         //reg_data[0] = 0x01; // sensor error conditins register
         let status = self.read_register(0x01)?;
-        if (status & 0b0000_0001) == 0 {
+        if (status & 0b0000_0001) != 0 {
             return Err(Error::InvalidDevice);
         }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,6 +9,8 @@ pub enum Error<E> {
     InvalidDevice,
     /// Invalid configuration
     InvalidConfig,
+    /// Timeout error
+    Timeout,
 }
 
 /// Accelerometer power modes


### PR DESCRIPTION
Fixing the issue where data was not being read properly initially because device was not ready to send data after configuration.